### PR TITLE
Stringify item to JSON before assigning to data-value

### DIFF
--- a/Typeahead.js
+++ b/Typeahead.js
@@ -18,6 +18,7 @@
 define([
     "dojo/_base/declare",
     "dojo/query",
+    "dojo/json",
     "dojo/_base/lang",
     "dojo/_base/window",
     "dojo/on",
@@ -31,7 +32,7 @@ define([
     "dojo/NodeList-dom",
     "dojo/NodeList-traverse",
     "dojo/domReady!"
-], function (declare, query, lang, win, on, domClass, domAttr, domConstruct, domGeom, domStyle, array, support) {
+], function (declare, query, JSON, lang, win, on, domClass, domAttr, domConstruct, domGeom, domStyle, array, support) {
     "use strict";
 
     var provideSelector = '[data-provide="typeahead"]';
@@ -61,7 +62,7 @@ define([
         },
         select: function () {
             var li = query('.active', this.menuNode)[0];
-            this.domNode.value = this.updater(domAttr.get(li, 'data-value'));
+            this.domNode.value = this.updater(JSON.parse(domAttr.get(li, 'data-value')));
             on.emit(this.domNode, 'change', { bubbles:true, cancelable:true });
             return this.hide();
         },
@@ -128,7 +129,7 @@ define([
         render: function (items) {
             items = array.map(items, function (item, i) {
                 var li = domConstruct.toDom(this.options.item);
-                domAttr.set(li, 'data-value', item);
+                domAttr.set(li, 'data-value', JSON.stringify(item));
                 query('a', li)[0].innerHTML = this.highlighter(item);
                 if (i === 0) { domClass.add(li, 'active'); }
                 return li.outerHTML;


### PR DESCRIPTION
I was attempting to implement autocomplete / typeahead functionality with a search web service that returns a JSON array of  hashes as the result and found that data-value attrib only holds a string. 
This change serializes the item using JSON.stringify and parses the selected item.

i,e. the following options

```
source: [{id:1,label:'One'},{id:2,label:'Two'},{id:3,label:'Three'}],
matcher: function(item) {return (item.label.toString().toLowerCase().indexOf(this.query.toLowerCase()))+1;},
highlighter:function(item){return item.label;},
updater:function(item){alert("selected item id " + item.id);return item.label;},
```
