### PR TITLE
Add dojo sdk via bower.

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+    "directory": "vendor/dojo"
+}

--- a/README.md
+++ b/README.md
@@ -5,13 +5,7 @@ An implementation of the excellent [Bootstrap](http://getbootstrap.com) framewor
 ## Quick Start
 
 + `git clone git://github.com/xsokev/Dojo-Bootstrap.git`
-+ Add [dojo sdk](https://github.com/dojo) (or a symbolic link to the dojo sdk) under the vendor folder as follows:
-```
-└── vendor
-    └── dojo
-        ├── dojo
-        └── util
-```
++ Add the [dojo sdk](https://github.com/dojo) to `vendor/dojo` by running `bower install`.
 + Point your browser to `http://host/path/to/Dojo-bootstrap/tests/index.html`
 
 ## Integration

--- a/bower.json
+++ b/bower.json
@@ -24,5 +24,9 @@
     "tests",
     "composer.json",
     "Gruntfile.js"
-  ]
+  ],
+  "devDependencies": {
+    "dojo": "^1.10",
+    "util": "dojo-util#^1.10"
+  }
 }


### PR DESCRIPTION
Makes is easier to get up and running for dev.

Would also need to update https://github.com/xsokev/Dojo-Bootstrap/wiki/Tests if this change is merged.