### PR TITLE
Travis/Sauce Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 
 vendor/
 node_modules/
+secrets.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: node_js
+node_js:
+  - "0.12"
+before_install:
+  - npm install -g grunt-cli
+  - npm install -g bower
+  - bower install
+  - npm update
+  - bower update
+notifications:
+  email:
+    on_success: change
+    on_failure: change
+sudo: false
+cache:
+  directories:
+    - node_modules
+    - vendor/dojo

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,17 +1,33 @@
 /*jshint node:true */
 module.exports = function (grunt) {
+  var secrets;
+  try {
+    secrets = grunt.file.readJSON('secrets.json');
+  } catch (e) {
+    // swallow for travis where environment variables are
+    // set in .travis.yml
+    secrets = {};
+  }
   grunt.initConfig({
     intern: {
+      options: {
+        runType: 'runner'
+      },
       complete: {
         options: {
-          config: 'tests/intern',
-          runType: 'runner'
+          config: 'tests/intern'
         }
       },
       fast: {
         options: {
-          config: 'tests/intern-watch',
-          runType: 'runner'
+          config: 'tests/intern-watch'
+        }
+      },
+      sauce: {
+        options: {
+          sauceUsername: secrets.sauceUsername,
+          sauceAccessKey: secrets.sauceAccessKey,
+          config: 'tests/intern-sauce'
         }
       }
     },
@@ -40,4 +56,5 @@ module.exports = function (grunt) {
   // Register tasks
   grunt.registerTask('default', ['selenium', 'watch']);
   grunt.registerTask('test', ['selenium', 'intern:complete']);
+  grunt.registerTask('travis', ['intern:sauce']);
 };

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/xsokev/Dojo-Bootstrap.svg?branch=master)](https://travis-ci.org/xsokev/Dojo-Bootstrap)
+[![Sauce Test Status](https://saucelabs.com/browser-matrix/<username>.svg)](https://saucelabs.com/u/<username>)
 # Dojo-Bootstrap
 
 An implementation of the excellent [Bootstrap](http://getbootstrap.com) framework using the [Dojo Toolkit](http://dojotoolkit.org). This project replaces the Bootstrap JavaScript components with AMD-compatible Dojo modules. Tested with Dojo 1.9.3 and Bootstrap 3.1.1.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-se-launch": "^0.1.0",
     "grunt-selenium-simple": "^0.1.1",
-    "intern": "^2.1.0"
+    "intern": "^2.2.2"
+  },
+  "scripts": {
+    "test": "grunt travis --verbose"
   }
 }

--- a/secrets.json.sample
+++ b/secrets.json.sample
@@ -1,0 +1,4 @@
+{
+    "sauceUsername": "<username>",
+    "sauceAccessKey": "<key>"
+}

--- a/tests/functional/datepicker.js
+++ b/tests/functional/datepicker.js
@@ -30,7 +30,19 @@ define([
         'updated date on keyup': function () {
             return this.remote
                 .findById('mydate')
-                    .type([keys.BACKSPACE, '1'])
+                    .type([keys.ARROW_RIGHT,
+                        keys.ARROW_RIGHT,
+                        keys.ARROW_RIGHT,
+                        keys.ARROW_RIGHT,
+                        keys.ARROW_RIGHT,
+                        keys.ARROW_RIGHT,
+                        keys.ARROW_RIGHT,
+                        keys.ARROW_RIGHT,
+                        keys.ARROW_RIGHT,
+                        keys.ARROW_RIGHT,
+                        keys.ARROW_RIGHT,
+                        keys.BACKSPACE,
+                        '1'])
                     .end()
                 .executeAsync(function (done) {
                     var query = require('dojo/query');

--- a/tests/intern-sauce.js
+++ b/tests/intern-sauce.js
@@ -1,0 +1,80 @@
+// Learn more about configuring this file at <https://github.com/theintern/intern/wiki/Configuring-Intern>.
+// These default settings work OK for most people. The options that *must* be changed below are the
+// packages, suites, excludeInstrumentation, and (if you want functional tests) functionalSuites.
+define({
+    tunnel: 'SauceLabsTunnel',
+
+    // The port on which the instrumenting proxy will listen
+    proxyPort: 9000,
+
+    // A fully qualified URL to the Intern proxy
+    proxyUrl: 'http://localhost:9000/',
+
+    // Default desired capabilities for all environments. Individual capabilities can be overridden by any of the
+    // specified browser environments in the `environments` array below as well. See
+    // https://code.google.com/p/selenium/wiki/DesiredCapabilities for standard Selenium capabilities and
+    // https://saucelabs.com/docs/additional-config#desired-capabilities for Sauce Labs capabilities.
+    // Note that the `build` capability will be filled in with the current commit ID from the Travis CI environment
+    // automatically
+    capabilities: {
+        // 'selenium-version': '2.45.0'
+    },
+
+    // Browsers to run integration testing against. Note that version numbers must be strings if used with Sauce
+    // OnDemand. Options that will be permutated are browserName, version, platform, and platformVersion; any other
+    // capabilities options specified for an environment will be copied as-is
+    environments: [
+        {
+            browserName: 'safari',
+            platform: 'OS X 10.10'
+        }, {
+            browserName: 'firefox',
+            platform: 'Windows 8.1'
+        }, {
+            browserName: 'chrome',
+            platform: 'Windows 8.1'
+        }, {
+            browserName: 'internet explorer',
+            version: '11',
+            platform: 'Windows 8.1'
+        }, {
+            browserName: 'internet explorer',
+            version: '10',
+            platform: 'Windows 8'
+        }, {
+            browserName: 'internet explorer',
+            version: '9',
+            platform: 'Windows 7'
+        }
+    ],
+
+    // Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service
+    maxConcurrency: 3,
+
+    // The desired AMD loader to use when running unit tests (client.html/client.js). Omit to use the default Dojo
+    // loader
+    useLoader: {
+        'host-node': 'dojo/dojo',
+        'host-browser': 'node_modules/dojo/dojo.js'
+    },
+
+    // Configuration options for the module loader; any AMD configuration options supported by the specified AMD loader
+    // can be used here
+    loader: {
+        // Packages that should be registered with the loader in each testing environment
+        packages: [
+            { name: 'bootstrap', location: '.' },
+            { name: 'tests', location: './tests' },
+            { name: 'dojo', location: './vendor/dojo/dojo' }
+        ]
+    },
+
+    // Non-functional test suite(s) to run in each browser
+    suites: [ 'tests/tab', 'tests/collapse', 'tests/popover', 'tests/datepicker', 'tests/tooltip' ],
+
+    // Functional test suite(s) to run in each browser once non-functional tests are completed
+    functionalSuites: [ 'tests/functional/collapse', 'tests/functional/datepicker' ],
+
+    // A regular expression matching URLs to files that should not be included in code coverage analysis
+    excludeInstrumentation: /^(?:tests|node_modules|vendor)(\/|\\)/
+});

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -14,21 +14,21 @@ define({
 	// https://saucelabs.com/docs/additional-config#desired-capabilities for Sauce Labs capabilities.
 	// Note that the `build` capability will be filled in with the current commit ID from the Travis CI environment
 	// automatically
-  capabilities: {
-    'selenium-version': '2.45.0'
-  },
+    capabilities: {
+        'selenium-version': '2.45.0'
+    },
 
-  // Browsers to run integration testing against. Note that version numbers must be strings if used with Sauce
-  // OnDemand. Options that will be permutated are browserName, version, platform, and platformVersion; any other
-  // capabilities options specified for an environment will be copied as-is
-  environments: [
-    // NOTE: install drivers for browsers installed on your system
-    // and uncomment the following lines to test
-    // { browserName: 'internet explorer' },
-    // { browserName: 'safari' },
-    { browserName: 'firefox' },
-    { browserName: 'chrome' }
-  ],
+    // Browsers to run integration testing against. Note that version numbers must be strings if used with Sauce
+    // OnDemand. Options that will be permutated are browserName, version, platform, and platformVersion; any other
+    // capabilities options specified for an environment will be copied as-is
+    environments: [
+        // NOTE: install drivers for browsers installed on your system
+        // and uncomment the following lines to test
+        // { browserName: 'internet explorer' },
+        // { browserName: 'safari' },
+        { browserName: 'firefox' },
+        { browserName: 'chrome' }
+    ],
 
 	// Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service
 	maxConcurrency: 3,

--- a/tests/popover.js
+++ b/tests/popover.js
@@ -14,27 +14,32 @@ define([
   var target;
   var contentNode;
   var originalTrans;
+  var containerNode;
 
   registerSuite({
     name: 'collapse',
     setup: function () {
       originalTrans = support.trans;
+      containerNode = domConstruct.create('div', null, document.body);
     },
     teardown: function () {
       support.trans = originalTrans;
     },
+    afterEach: function () {
+      domConstruct.empty(containerNode);
+    },
     'should be defined on NodeList object':function () {
-        assert.ok(query(document.body).popover);
+      assert.ok(query(containerNode).popover);
     },
 
     'should return element':function() {
-      assert.strictEqual(document.body, query(document.body).popover()[0]);
+      assert.strictEqual(containerNode, query(containerNode).popover()[0]);
     },
 
     'should render popover element': {
       setup: function() {
         support.trans = false;
-        contentNode = domConstruct.place('<a href="#" title="mdo" data-content="http://twitter.com/mdo">@mdo</a>', document.body);
+        contentNode = domConstruct.place('<a href="#" title="mdo" data-content="http://twitter.com/mdo">@mdo</a>', containerNode);
       },
       runTest: function() {
         var popover = query(contentNode).popover('show');
@@ -43,7 +48,6 @@ define([
         assert.ok(!query('.popover').length, 'popover removed');
       },
       teardown: function() {
-        document.body.innerHTML = '';
         support.trans = true;
       }
     },
@@ -51,14 +55,13 @@ define([
     'should store popover instance in popover data object': {
       setup: function() {
         support.trans = false;
-        contentNode = domConstruct.place('<a href="#" title="mdo" data-content="http://twitter.com/mdo">@mdo</a>', document.body);
+        contentNode = domConstruct.place('<a href="#" title="mdo" data-content="http://twitter.com/mdo">@mdo</a>', containerNode);
       },
       runTest: function() {
         var popover = query(contentNode).popover();
         assert.ok(!!support.getData(popover, 'bs.popover'), 'popover instance exists');
       },
       teardown: function() {
-        document.body.innerHTML = '';
         support.trans = true;
       }
     },
@@ -66,14 +69,13 @@ define([
     'should store popover trigger in popover instance object': {
       setup: function() {
         support.trans = false;
-        contentNode = domConstruct.place('<a href="#" title="ResentedHook">@ResentedHook</a>', document.body);
+        contentNode = domConstruct.place('<a href="#" title="ResentedHook">@ResentedHook</a>', containerNode);
       },
       runTest: function() {
         /*var popover = */query(contentNode).popover('show');
         assert.ok(!!support.getData(query('.popover')[0], 'bs.popover'), 'popover trigger stored in instance data');
       },
       teardown: function() {
-        document.body.innerHTML = '';
         support.trans = true;
       }
     },
@@ -81,10 +83,10 @@ define([
     'should get title and content from options': {
       setup: function() {
         support.trans = false;
-        contentNode = domConstruct.place('<a href="#">@fat</a>', document.body);
+        contentNode = domConstruct.place('<a href="#">@fat</a>', containerNode);
       },
       runTest: function() {
-       var popover = query(contentNode).popover({
+        var popover = query(contentNode).popover({
           title: function () {
             return '@fat';
           },
@@ -100,7 +102,6 @@ define([
         assert.ok(!query('.popover').length, 'popover removed');
       },
       teardown: function() {
-        document.body.innerHTML = '';
         support.trans = true;
       }
     },
@@ -108,7 +109,7 @@ define([
     'should get title and content from attributes': {
       setup: function() {
         support.trans = false;
-        contentNode = domConstruct.place('<a href="#" title="@mdo" data-content="loves data attributes (づ｡◕‿‿◕｡)づ ︵ ┻━┻" >@mdo</a>', document.body);
+        contentNode = domConstruct.place('<a href="#" title="@mdo" data-content="loves data attributes (づ｡◕‿‿◕｡)づ ︵ ┻━┻" >@mdo</a>', containerNode);
       },
       runTest: function() {
        var popover = query(contentNode).popover().popover('show');
@@ -119,7 +120,6 @@ define([
         assert.ok(!query('.popover').length, 'popover removed');
       },
       teardown: function() {
-        document.body.innerHTML = '';
         support.trans = true;
       }
     },
@@ -127,7 +127,7 @@ define([
     'should get title and content from attributes #2': {
       setup: function() {
         support.trans = false;
-        contentNode = domConstruct.place('<a href="#" title="@mdo" data-content="loves data attributes (づ｡◕‿‿◕｡)づ ︵ ┻━┻" >@mdo</a>', document.body);
+        contentNode = domConstruct.place('<a href="#" title="@mdo" data-content="loves data attributes (づ｡◕‿‿◕｡)づ ︵ ┻━┻" >@mdo</a>', containerNode);
       },
       runTest: function() {
         var popover = query(contentNode).popover({
@@ -141,7 +141,6 @@ define([
         assert.ok(!query('.popover').length, 'popover removed');
       },
       teardown: function() {
-        document.body.innerHTML = '';
         support.trans = true;
       }
     },
@@ -149,8 +148,8 @@ define([
     'should not duplicate HTML object': {
      setup: function() {
         support.trans = false;
-        target = domConstruct.place('<a href="#">@fat</a>', document.body);
-        contentNode = domConstruct.place('<div>', document.body);
+        target = domConstruct.place('<a href="#">@fat</a>', containerNode);
+        contentNode = domConstruct.place('<div>', containerNode);
       },
       runTest: function() {
         var $div = query(contentNode).html('loves writing tests （╯°□°）╯︵ ┻━┻</div>');
@@ -171,7 +170,7 @@ define([
         assert.ok(!query('.popover').length, 'popover was removed');
       },
       teardown: function() {
-        document.body.innerHTML = '';
+        domConstruct.destroy(target);
         support.trans = true;
       }
     },
@@ -179,7 +178,7 @@ define([
     'should respect custom classes': {
       setup: function() {
         support.trans = false;
-        contentNode = domConstruct.place('<a href="#">@fat</a>', document.body);
+        contentNode = domConstruct.place('<a href="#">@fat</a>', containerNode);
       },
       runTest: function() {
         var popover = query(contentNode).popover({
@@ -194,7 +193,6 @@ define([
         assert.ok(!query('.popover').length, 'popover removed');
       },
       teardown: function() {
-        document.body.innerHTML = '';
         support.trans = true;
       }
     },
@@ -202,7 +200,7 @@ define([
     'should destroy popover': {
       setup: function() {
         // support.trans = false;
-        contentNode = domConstruct.place('<div/>', document.body);
+        contentNode = domConstruct.place('<div/>', containerNode);
       },
       runTest: function() {
         var popover = query(contentNode).popover({
@@ -226,7 +224,6 @@ define([
         // ok(!$._data(popover[0], 'events').mouseover && !$._data(popover[0], 'events').mouseout, 'popover does not have any events')
       },
       teardown: function() {
-        document.body.innerHTML = '';
         //support.trans = true;
       }
     }


### PR DESCRIPTION
All tests (unit and functional) are passing for me using my own sauce account.

A few things that still need to be done by a contributor/owner:
- [ ] Log into https://travis-ci.org/ and turn on this repository
- [ ] Sign up for a free open sauce account at https://saucelabs.com/opensauce
- [ ] Go [here](https://docs.saucelabs.com/ci-integrations/travis-ci/#adding-credentials-for-a-public-github-repo) and generate encryption keys for travis and put them in `.travis.yml`.
- [ ] Fill in `<username>` at the top of `README.md` for the sauce test status badge.

In order to run the tests locally you will need to create `secrets.json` and define the sauce username and key (see `secrets.json.sample`).

Not sure if this is exactly the setup that you want but thought that it would be a good start for you.

Also, after struggling through this and talking with the intern guys it sounds like browserstack may be a better option. I'm going to investigate using them for one of my projects. It would be simple to switch to them at some point in the future. But for now the tests are running well on sauce.
